### PR TITLE
Improve test robustness on MacOS

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,6 @@ deps =
 commands =
     pipenv run pip install pip==18.0
     pipenv install --dev --ignore-pipfile
-    pipenv run py.test -v
+    pipenv run py.test -v {posargs}
 
 


### PR DESCRIPTION
The functions to create temporary paths on MacOS return paths which
are not resolved, full paths and instead could be behind links. To
work around this, always 'resolve()' paths.